### PR TITLE
Enable GNOME 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "uuid": "netspeed@alynx.one",
   "url": "https://github.com/AlynxZhou/gnome-shell-extension-net-speed/",
   "version": 7,
-  "shell-version": ["40", "41", "42","43"]
+  "shell-version": ["40", "41", "42", "43", "44"]
 }


### PR DESCRIPTION
Add "44" to supported `shell-version`s.

(The current version works as is on my machine - Fedora 38 w/ GNOME 44).